### PR TITLE
Fixes to the KGE docstring for sphinx rendering

### DIFF
--- a/tutorials/Kling_Gupta_Efficiency.ipynb
+++ b/tutorials/Kling_Gupta_Efficiency.ipynb
@@ -5,7 +5,7 @@
    "id": "0950f056",
    "metadata": {},
    "source": [
-    "# Kling–Gupta efficiency (KGE)\n",
+    "# Kling–Gupta Efficiency (KGE)\n",
     "In this notebook, we will explore the Kling-Gupta Efficiency (KGE) which is widely used to evaluate the performance of hydrological models. KGE is a performance metric that decomposes the error into three components:\n",
     "correlation,  variability and bias.\n",
     "\n",

--- a/tutorials/Tutorial_Gallery.ipynb
+++ b/tutorials/Tutorial_Gallery.ipynb
@@ -54,6 +54,7 @@
     "- [RMSE](./Root_Mean_Squared_Error.ipynb)\n",
     "- [MSE](./Mean_Squared_Error.ipynb)\n",
     "- [Pearson's Correlation](./Pearsons_Correlation.ipynb)\n",
+    "- [Kling-Gupta Efficiency](./Kling_Gupta_Efficiency.ipynb)\n",
     "- [Quantile Loss](./Quantile_Loss.ipynb)\n",
     "- [Murphy Diagrams](./Murphy_Diagrams.ipynb)\n",
     "- [Flip-Flop Index](./Flip_Flop_Index.ipynb)\n",


### PR DESCRIPTION
Mostly fixes to the KGE docstring to get it to render nicely in readthedocs. Please take a detailed look to make sure no inaccuracies were introduced during this.

I also added the KGE notebook to the tutorial gallery, and adjusted capitalisation
